### PR TITLE
fix metric error when drop_last isTrue in dataloader

### DIFF
--- a/moment_localization/run.py
+++ b/moment_localization/run.py
@@ -201,6 +201,7 @@ def train_epoch(train_loader, model, optimizer, verbose=False):
         pbar.close()
 
     annotations = train_loader.dataset.annotations
+    annotations = [annotations[key] for key in sorted(sorted_segments_dict.keys())]
     sorted_segments = [sorted_segments_dict[key] for key in sorted(sorted_segments_dict.keys())]
     result = eval.evaluate(sorted_segments, annotations)
 
@@ -229,6 +230,7 @@ def test_epoch(test_loader, model, verbose=False, save_results=False):
     if verbose:
         pbar.close()
     annotations = test_loader.dataset.annotations
+    annotations = [annotations[key] for key in sorted(sorted_segments_dict.keys())]
     sorted_segments = [sorted_segments_dict[key] for key in sorted(sorted_segments_dict.keys())]
     saved_dict = [saved_dict[key] for key in sorted(saved_dict.keys())]
     if save_results:


### PR DESCRIPTION
When `drop_last` is `True` in the DataLoader (train_loader), the lengths of `annotations` and `sorted_segments` in `run.py` are different. Then the predicted time and ground truth time are not matching, and the evalutation results (tIoU) are totally wrong.

The error can be fixed by selecting these `annotations` whose `index` are in the `sorted_segments_dict.`